### PR TITLE
Collector interface/implementation

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,40 @@
+package mw
+
+// Collector should contain a list of Middleware funcs that are supposed to be
+// applied to the request with given HTTP method.
+type Collector interface {
+	// AddMiddleware should make the provided chain available by HTTP method.
+	AddMiddleware(method string, chain ...Middleware) Collector
+	// Middleware should return the list of middleware functions registered for provided method.
+	Middleware(method string) []Middleware
+}
+
+// List provides ability to register/unregister middleware for HTTP methods.
+type List struct {
+	middleware map[string][]Middleware
+}
+
+// NewList is a constructor func for middleware List.
+func NewList() *List {
+	return &List{
+		middleware: make(map[string][]Middleware),
+	}
+}
+
+// AddMiddleware adds middleware funcs to existing ones for provided HTTP method.
+func (l *List) AddMiddleware(method string, chain ...Middleware) Collector {
+	if _, ok := l.middleware[method]; !ok {
+		l.middleware[method] = []Middleware{}
+	}
+	l.middleware[method] = append(l.middleware[method], chain...)
+	// return itself in order to use func in a chain
+	return l
+}
+
+// Middleware returns middleware func registered for provided method or an empty list.
+func (l *List) Middleware(method string) []Middleware {
+	if mw, ok := l.middleware[method]; ok {
+		return mw
+	}
+	return []Middleware{}
+}

--- a/collector.go
+++ b/collector.go
@@ -9,7 +9,8 @@ type Collector interface {
 	Middleware(method string) []Middleware
 }
 
-// List provides ability to register/unregister middleware for HTTP methods.
+// List provides ability to register/unregister middleware for HTTP methods. This
+// is a basic Collector interface implementation.
 type List struct {
 	middleware map[string][]Middleware
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -5,24 +5,6 @@ import (
 	"testing"
 )
 
-var (
-	mwOne Middleware = func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-		})
-	}
-	mwTwo Middleware = func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-		})
-	}
-	mwThree Middleware = func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-		})
-	}
-)
-
 func Test_List(t *testing.T) {
 	t.Run("Given a middleware List", func(t *testing.T) {
 		list := NewList()
@@ -30,7 +12,7 @@ func Test_List(t *testing.T) {
 			t.Error("middleware map should be empty after initialization")
 		}
 		t.Run("register middleware for HTTP method", func(t *testing.T) {
-			list.AddMiddleware(http.MethodGet, mwOne)
+			list.AddMiddleware(http.MethodGet, middlewareOne)
 			mw, ok := list.middleware[http.MethodGet]
 			if !ok {
 				t.Errorf("middleware map is expected to contain key %q", http.MethodGet)
@@ -40,7 +22,7 @@ func Test_List(t *testing.T) {
 			}
 		})
 		t.Run("add middleware func(s) to existing chain", func(t *testing.T) {
-			list.AddMiddleware(http.MethodGet, mwTwo, mwThree)
+			list.AddMiddleware(http.MethodGet, middlewareTwo, middlewareThree)
 			mw, ok := list.middleware[http.MethodGet]
 			if !ok {
 				t.Errorf("middleware map is expected to contain key %q", http.MethodGet)
@@ -58,13 +40,13 @@ func Test_List(t *testing.T) {
 		t.Run("get middleware registered for HTTP method", func(t *testing.T) {
 			mw := list.Middleware(http.MethodGet)
 			if mw[0] == nil {
-				t.Error("mwOne should not be nil")
+				t.Error("middlewareOne should not be nil")
 			}
 			if mw[1] == nil {
-				t.Error("mwTwo should not be nil")
+				t.Error("middlewareTwo should not be nil")
 			}
 			if mw[2] == nil {
-				t.Error("mwThree should not be nil")
+				t.Error("middlewareThree should not be nil")
 			}
 		})
 	})

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,71 @@
+package mw
+
+import (
+	"net/http"
+	"testing"
+)
+
+var (
+	mwOne Middleware = func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+	mwTwo Middleware = func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+	mwThree Middleware = func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	}
+)
+
+func Test_List(t *testing.T) {
+	t.Run("Given a middleware List", func(t *testing.T) {
+		list := NewList()
+		if len(list.middleware) != 0 {
+			t.Error("middleware map should be empty after initialization")
+		}
+		t.Run("register middleware for HTTP method", func(t *testing.T) {
+			list.AddMiddleware(http.MethodGet, mwOne)
+			mw, ok := list.middleware[http.MethodGet]
+			if !ok {
+				t.Errorf("middleware map is expected to contain key %q", http.MethodGet)
+			}
+			if len(mw) != 1 {
+				t.Errorf("middleware list for key %q should contain exactly one middleware", http.MethodGet)
+			}
+		})
+		t.Run("add middleware func(s) to existing chain", func(t *testing.T) {
+			list.AddMiddleware(http.MethodGet, mwTwo, mwThree)
+			mw, ok := list.middleware[http.MethodGet]
+			if !ok {
+				t.Errorf("middleware map is expected to contain key %q", http.MethodGet)
+			}
+			if len(mw) != 3 {
+				t.Errorf("middleware list for key %q should contain three middleware funcs", http.MethodGet)
+			}
+		})
+		t.Run("get an empty middleware chain (by default)", func(t *testing.T) {
+			mw := list.Middleware(http.MethodPost)
+			if len(mw) != 0 {
+				t.Errorf("middleware list should be empty for method %q", http.MethodPost)
+			}
+		})
+		t.Run("get middleware registered for HTTP method", func(t *testing.T) {
+			mw := list.Middleware(http.MethodGet)
+			if mw[0] == nil {
+				t.Error("mwOne should not be nil")
+			}
+			if mw[1] == nil {
+				t.Error("mwTwo should not be nil")
+			}
+			if mw[2] == nil {
+				t.Error("mwThree should not be nil")
+			}
+		})
+	})
+}


### PR DESCRIPTION
Contains simple implementation of `Collector` interface that can be inherited by modules of an application built with `go-middleware`.