### PR TITLE
Ignore nil panics

### DIFF
--- a/panic_recover.go
+++ b/panic_recover.go
@@ -11,6 +11,9 @@ import (
 // supported interfaces (error/Error) - it tries to convert a panic to a string.
 func PanicHandler(w http.ResponseWriter, p interface{}) {
 	switch e := p.(type) {
+	case nil:
+		// ignore (panics that throw nil can be used to indicate that handler finished
+		// the task successfuly and all the next handlers can be igored)
 	case Error:
 		// retrieve status code and error message
 		http.Error(w, e.Error(), e.Code())


### PR DESCRIPTION
Treat `nil` panics as a successful ending of the process

Example:
```go
func doStuff() error {
    // .......
}

panic(doStuff())
```
if `doStuff` returns `nil` error will be ignored