### PR TITLE
remove defer statement

### DIFF
--- a/async_request.go
+++ b/async_request.go
@@ -208,7 +208,7 @@ func (at *asyncTask) Do(ctx context.Context, handler func(stop <-chan struct{}) 
 // keepResult - at the expiration of a given period of time the result will be
 // unavailable (deleted).
 //
-// NOTE: Do not use defer statements to check the status of task or send error or
+// NOTE: Do not use defer statements to check the status of task, send error or
 // any response when using PanicRecover middleware.
 func AsyncRequest(reqTimeout, asyncTimeout, keepResult time.Duration) Middleware {
 	// no sense to use this middleware if the following condition is not satisfied


### PR DESCRIPTION
:warning: Do not use `defer` to send HTTP response because it will be sent even if the panic occurs :warning:
All the errors should be caught and sent by `PanicRecover` middleware (that is not possible since `AsyncRequest` modifies headers and body using defer)